### PR TITLE
Render IdCat mòbil icon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,11 @@ gem "decidim-templates", DECIDIM_VERSION
 
 gem "decidim-decidim_awesome", "~> 0.8"
 
+gem "decidim-idcat_mobil", "~> 0.2.1"
+# Although `omniauth-rails_csrf_protection` is already a Decidim dependency, it is not working unless declared here.
+# In meta.decidim.org, which is at Decidim v0.26, this declaration is not required. Try to remove it after upgrading to Decidim v0.26
+gem "omniauth-rails_csrf_protection"
+
 gem "bootsnap", "~> 1.3"
 gem "wicked_pdf", "~> 2.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,6 +308,10 @@ GEM
       wkhtmltopdf-binary (~> 0.12)
     decidim-generators (0.25.2)
       decidim-core (= 0.25.2)
+    decidim-idcat_mobil (0.2.1)
+      decidim (>= 0.25.2)
+      decidim-core (>= 0.25.2)
+      omniauth-idcat_mobil (~> 0.4.0)
     decidim-initiatives (0.25.2)
       decidim-admin (= 0.25.2)
       decidim-comments (= 0.25.2)
@@ -836,6 +840,8 @@ DEPENDENCIES
   decidim-conferences (= 0.25.2)
   decidim-decidim_awesome (~> 0.8)
   decidim-dev (= 0.25.2)
+  decidim-file_authorization_handler (~> 0.25.2)!
+  decidim-idcat_mobil (~> 0.2.1)
   decidim-initiatives (= 0.25.2)
   decidim-templates (= 0.25.2)
   faker

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,6 +12,9 @@
 
 default: &default
   omniauth:
+    idcat_mobil:
+      enabled: true
+      icon_path: media/images/idcat_mobil-icon.svg
     facebook:
       # It must be a boolean. Remember ENV variables doesn't support booleans.
       enabled: false
@@ -43,17 +46,22 @@ default: &default
     number_of_trustees: 2
 
 development:
-  <<: *default
   secret_key_base: 612c62f9c44ff84427c1f6ac3d85e3d3235cc5ff585c1478fa040a37bad6ae5c6eb6485937249373348aa1a961d0dd74188ae73742d1fce034043be1160fb3bf
   omniauth:
     developer:
       enabled: true
       icon: phone
+    idcat_mobil:
+      enabled: true
+      icon_path: media/images/idcat_mobil-icon.svg
 
 test:
   <<: *default
   secret_key_base: 354a67e9db7fa5d3c5b4b12207b66009b298dab0f31f4e59ff2eb1749f8e7997e13d554eececa2d499d5dabf7b428d944cd22be43fc98592cf2ae946283b066f
   omniauth:
+    idcat_mobil:
+      enabled: true
+      icon_path: media/images/idcat_mobil-icon.svg
     facebook:
       enabled: true
       app_id: fake-facebook-app-id
@@ -95,6 +103,10 @@ staging:
 # instead read values from the environment.
 production:
   <<: *default
+  omniauth:
+    idcat_mobil:
+      enabled: true
+      icon_path: media/images/idcat_mobil-icon.svg
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   smtp_username: <%= ENV["SMTP_USERNAME"] %>
   smtp_password: <%= ENV["SMTP_PASSWORD"] %>


### PR DESCRIPTION
Render the icon for the IdCat mòbil OAuth integration in the corresponding authentication button.

![imatge](https://user-images.githubusercontent.com/199462/175034883-2f219077-6aec-4220-a66f-0e7cea04a1aa.png)
