### PR TITLE
Enable IdCat mòbil via configuration

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -105,7 +105,7 @@ production:
   <<: *default
   omniauth:
     idcat_mobil:
-      enabled: true
+      enabled: <%= ENV["IDCAT_MOBIL_ENABLED"] %>
       icon_path: media/images/idcat_mobil-icon.svg
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   smtp_username: <%= ENV["SMTP_USERNAME"] %>


### PR DESCRIPTION
This PR makes the IdCat mobil integration enabled/disabled via config var, without the need to re-deploy the application 