### PR TITLE
Stay with sidekiq 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ group :development, :staging do
 end
 
 group :production, :staging do
-  gem "sidekiq"
+  gem "sidekiq", "~>6.3.1"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -727,8 +727,6 @@ GEM
       wisper (>= 1.6.1)
     redcarpet (3.6.0)
     redis (4.8.1)
-    redis-client (0.17.0)
-      connection_pool
     regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -813,11 +811,10 @@ GEM
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     seven_zip_ruby (1.3.0)
-    sidekiq (7.1.4)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.14.0)
+    sidekiq (6.3.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     simplecov (0.19.1)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -941,7 +938,7 @@ DEPENDENCIES
   puma (>= 5.0.0)
   rspec-rails
   rubocop-rails
-  sidekiq
+  sidekiq (~> 6.3.1)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   web-console (~> 4.0)
@@ -951,4 +948,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.3.4
+   2.3.6


### PR DESCRIPTION
The last merge updated sidekiq to version 7, but this version is incompatible with the deployed one.