### PR TITLE
Fix mixed conflicts in list in the admin panel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/CodiTramuntana/decidim.git
-  revision: 6b920edcbd3b538660df5613e414fcbea13eddde
+  revision: ec190dbf06a535964697cd8e58fb8e8bd85dc32c
   branch: release/0.25-stable
   specs:
     decidim (0.25.2)
@@ -63,7 +63,7 @@ GIT
       decidim-core (= 0.25.2)
       decidim-meetings (= 0.25.2)
       wicked_pdf (~> 2.1)
-      wkhtmltopdf-binary (~> 0.12)
+      wkhtmltopdf-binary (~> 0.12.6.6)
     decidim-core (0.25.2)
       active_link_to (~> 1.0)
       acts_as_list (~> 0.9)
@@ -153,7 +153,7 @@ GIT
     decidim-forms (0.25.2)
       decidim-core (= 0.25.2)
       wicked_pdf (~> 2.1)
-      wkhtmltopdf-binary (~> 0.12)
+      wkhtmltopdf-binary (~> 0.12.6.6)
     decidim-generators (0.25.2)
       decidim-core (= 0.25.2)
     decidim-initiatives (0.25.2)
@@ -165,7 +165,7 @@ GIT
       virtus-multiparams (~> 0.1)
       wicked (~> 1.3)
       wicked_pdf (~> 2.1)
-      wkhtmltopdf-binary (~> 0.12)
+      wkhtmltopdf-binary (~> 0.12.6.6)
     decidim-meetings (0.25.2)
       decidim-core (= 0.25.2)
       decidim-forms (= 0.25.2)


### PR DESCRIPTION
Update Decidim 0.25 to last version to fix conflicts list in the Admin Panel.
This listing was not filtering by Organization and this patch solves that problem.