### PR TITLE
Update file_authorization_handler to Fix frozen string literal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ DECIDIM_VERSION = { git: "https://github.com/CodiTramuntana/decidim.git", branch
 
 gem "decidim", DECIDIM_VERSION
 gem "decidim-conferences", DECIDIM_VERSION
-gem "decidim-file_authorization_handler", git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", tag: "v0.25.2.3"
+gem "decidim-file_authorization_handler", git: "https://github.com/CodiTramuntana/decidim-file_authorization_handler.git", tag: "v0.25.2.4"
 gem "decidim-initiatives", DECIDIM_VERSION
 gem "decidim-templates", DECIDIM_VERSION
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/CodiTramuntana/decidim-file_authorization_handler.git
-  revision: 9bbdba223055a02065237cd84a3257b613b879e4
-  tag: v0.25.2.3
+  revision: 5f536bc77207ad0f0e6b783e7aee4a676a660541
+  tag: v0.25.2.4
   specs:
-    decidim-file_authorization_handler (0.25.2.3)
+    decidim-file_authorization_handler (0.25.2.4)
       decidim (~> 0.25.2)
       decidim-admin (~> 0.25.2)
       rails (>= 5.2)


### PR DESCRIPTION

Get backport https://github.com/CodiTramuntana/decidim-file_authorization_handler/pull/22 to fix the frozen string literal problem with the handler name.