### PR TITLE
Fix base64 gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "decidim-idcat_mobil", "~> 0.3.0"
 
 gem "decidim-cdtb"
 
+gem "base64", "0.1.0"
 gem "bootsnap", "~> 1.3"
 gem "wicked_pdf", "~> 2.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,7 +296,7 @@ GEM
       faraday_middleware (~> 1.0, >= 1.0.0.rc1)
       net-http-persistent (~> 4.0)
       nokogiri (~> 1, >= 1.10.8)
-    base64 (0.2.0)
+    base64 (0.1.0)
     batch-loader (1.5.0)
     bcrypt (3.1.20)
     better_html (1.0.16)
@@ -928,6 +928,7 @@ PLATFORMS
 
 DEPENDENCIES
   azure-storage-blob
+  base64 (= 0.1.0)
   bootsnap (~> 1.3)
   byebug (~> 11.0)
   daemons


### PR DESCRIPTION
The gem on the server comes by default with version 0.1.0. Cannot upgrade to newer versions and passenger is not raised so the required version has been set.

There is an option to do it with passenger nginx config and the https://www.phusionpassenger.com/docs/references/config_reference/nginx/#passenger_preload_bundler option but it is for version 6.0.13 and we have 6.0.12.