### PR TITLE
Fix wicked_pdf version to 2.7.0 and more

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "decidim-idcat_mobil", "~> 0.3.0"
 gem "decidim-cdtb"
 
 gem "bootsnap", "~> 1.3"
-gem "wicked_pdf", "~> 2.1"
+gem "wicked_pdf", "~> 2.7.0"
 
 # Blob storage in the cloud
 gem "azure-storage-blob"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -914,7 +914,7 @@ GEM
     websocket-extensions (0.1.5)
     wicked (1.4.0)
       railties (>= 3.0.7)
-    wicked_pdf (2.8.0)
+    wicked_pdf (2.7.0)
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)
@@ -953,7 +953,7 @@ DEPENDENCIES
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   web-console (~> 4.0)
-  wicked_pdf (~> 2.1)
+  wicked_pdf (~> 2.7.0)
 
 RUBY VERSION
    ruby 3.0.2p107

--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# This is a fix when sending the customized survey answer confirmation email
+require "webpacker/version"

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,10 @@
+---
+ca:
+  # Remove when create the translations in Decidim
+  decidim:
+    surveys:
+      survey_confirmation_mailer:
+        confirmation:
+          body: Has respost correctament el qüestionari %{questionnaire_title} dins de %{participatory_space}
+          subject: Confirmació de resposta al qüestionari %{questionnaire_title}
+        export_name: Repostes del qüestionari

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,10 @@
+---
+es:
+  # Remove when create the translations in Decidim
+  decidim:
+    surveys:
+      survey_confirmation_mailer:
+        confirmation:
+          body: Has contestado correctamente al cuestionario %{questionnaire_title} dentro de %{participatory_space}
+          subject: Confirmación de respuesta al cuestionario %{questionnaire_title}
+        export_name: Respuestas del cuestionario

--- a/spec/features/remove_overrides_spec.rb
+++ b/spec/features/remove_overrides_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 RSpec.describe "Overrides" do
   it "remove overrides after upgrading to v0.28" do
     # - Check header and application overrides views to set Google Tag Manager (see #22 and "Add Google Tag Manager to admin backoffice" in the README)
+    # - Remove `survey_confirmation_mailer` translations when Decidim has them
     expect(Decidim.version).to be < "0.28"
   end
 end


### PR DESCRIPTION
- There is an error with 2.8.0 version:

```
[ea6c829c-00d8-436a-aade-f4e0d0902ae6] ActionView::Template::Error (uninitialized constant WickedPdf::WickedPdfHelper::Assets::SprocketsEnvironment::Sprockets
Did you mean?  Socket
               Process
               IPSocket):
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]     3:   <head>
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]     4:       <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]     5:       <meta name="viewport" content="width=device-width">
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]     6:       <%= wicked_pdf_stylesheet_pack_tag "decidim_questionnaire_answers_pdf" %>
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]     7:       <title><%= @title %></title>
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]     8:     </head>
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]     9:   <body>
[ea6c829c-00d8-436a-aade-f4e0d0902ae6]
[ea6c829c-00d8-436a-aade-f4e0d0902ae6] wicked_pdf (2.8.0) lib/wicked_pdf/wicked_pdf_helper/assets.rb:47:in `instance'
[ea6c829c-00d8-436a-aade-f4e0d0902ae6] wicked_pdf (2.8.0) lib/wicked_pdf/wicked_pdf_helper/assets.rb:51:in `find_asset'
[ea6c829c-00d8-436a-aade-f4e0d0902ae6] wicked_pdf (2.8.0) lib/wicked_pdf/wicked_pdf_helper/assets.rb:208:in `find_asset'
[ea6c829c-00d8-436a-aade-f4e0d0902ae6] wicked_pdf (2.8.0) lib/wicked_pdf/wicked_pdf_helper/assets.rb:232:in `read_as
```

Issue: https://github.com/mileszs/wicked_pdf/issues/1102

- There is an error with Webpacker version too. A webpacker initializer has been created
- There are missing translations in surveys