### PR TITLE
Fix maps key in secrets file

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -25,6 +25,10 @@ Decidim.configure do |config|
     api_key: Rails.application.secrets.maps[:api_key],
     static: { url: "https://image.maps.ls.hereapi.com/mia/1.6/mapview" }
   }
+  config.geocoder = {
+    timeout: 5,
+    units: :km
+  }
 
   # Custom HTML Header snippets
   #

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -133,7 +133,7 @@ default: &default
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
   maps:
-    here_api_key: <%= ENV["GEOCODER_LOOKUP_API_KEY"] %>
+    api_key: <%= ENV["GEOCODER_LOOKUP_API_KEY"] %>
   etherpad:
     server: <%= ENV["ETHERPAD_SERVER"] %>
     api_key: <%= ENV["ETHERPAD_API_KEY"] %>


### PR DESCRIPTION
The key for the Here Maps api_key in `config/secrets.yml` was different from the one used in `config/initializers/decidim.rb`.