### PR TITLE
Add frame-src to CSP

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -34,6 +34,7 @@ Decidim.configure do |config|
   config.content_security_policies_extra = {
     "connect-src" => %w(https://*.blob.core.windows.net),
     "img-src" => %w(https://*.blob.core.windows.net),
+    "frame-src" => %w(https://*.blob.core.windows.net),
     "script-src" => %w(https://www.googletagmanager.com)
   }
 


### PR DESCRIPTION
PDF iframe not show because CSP.

<img width="1304" height="940" alt="imagen" src="https://github.com/user-attachments/assets/53f46c9b-4369-4ee5-901a-6f6682f94aa9" />
